### PR TITLE
Add principles and layer model for RPD v0.2 structure phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ You can:
 - Use it as a design lens in organizational reform
 - Adapt the framework to your own context (with attribution)
 
+## Structure
+
+The repository is beginning to move from pure concept definition toward a more explicit framework structure.
+
+Current supporting documents:
+- `docs/principles.md` — core design principles of Responsibility Pathway Design
+- `docs/layer-model.md` — layered model for locating responsibility, breaks, and repair paths
+
+This structure will be expanded gradually with future examples, terminology, and failure / repair cases.
+
 ---
 
 ## Background & original essays (Japanese)

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ The repository is beginning to move from pure concept definition toward a more e
 Current supporting documents:
 - `docs/principles.md` — core design principles of Responsibility Pathway Design
 - `docs/layer-model.md` — layered model for locating responsibility, breaks, and repair paths
+- `docs/failure-and-repair-examples.md` — compact framework-oriented examples of pathway failure, repair, rollback, and rebinding
 
-This structure will be expanded gradually with future examples, terminology, and failure / repair cases.
+This structure will be expanded gradually with future terminology, governance examples, and additional use cases.
 
 ---
 

--- a/docs/failure-and-repair-examples.md
+++ b/docs/failure-and-repair-examples.md
@@ -1,0 +1,179 @@
+# Responsibility Pathway Design — Failure and Repair Examples
+
+## Purpose
+This document provides compact example patterns showing how Responsibility Pathway Design (RPD) can be used to interpret failure and define repair.
+
+These are not legal case analyses.
+They are framework-oriented examples meant to show how pathway breaks can be located and how repair / rebinding can be designed.
+
+## Why Examples Matter
+A principles layer explains what RPD is.
+A layer model explains where responsibility should be examined.
+Examples help show how those ideas work in practice.
+
+RPD becomes more useful when it can answer not only:
+- what responsibility is
+but also:
+- where it broke
+- how it can be repaired
+- how authority should be rebound afterward
+
+---
+
+## Example 1: AI recommendation adopted without explicit ownership
+
+### Situation
+An AI-assisted workflow produces a recommendation used by staff in a high-impact operational decision.
+The output is presented as the next obvious action.
+No explicit human owner rebinds responsibility before execution.
+
+### Pathway break
+- Decision authority drifted into system fluency
+- Execution continued without explicit accountability rebinding
+- Record layer did not preserve a clear confirmation point
+
+### Failure reading
+The failure is not only "the AI was wrong" or "the operator clicked too quickly."
+The deeper issue is that delegation occurred without a visible authority handoff.
+
+### Repair path
+- restore explicit human confirmation before execution
+- bind decision ownership to a named role
+- require a visible override / approval checkpoint
+- preserve confirmation trace in the record layer
+
+### Design lesson
+Smooth recommendations must not erase the point where responsibility is rebound.
+
+---
+
+## Example 2: Organization delegates monitoring to AI but keeps no rollback owner
+
+### Situation
+An organization deploys AI-assisted monitoring for anomaly detection and automated alert handling.
+The system reduces human review load, but no clearly assigned role owns rollback when misclassification causes harm.
+
+### Pathway break
+- execution and escalation moved into system flow
+- repair authority was never assigned
+- rollback existed technically, but not organizationally
+
+### Failure reading
+This is not only a tooling failure.
+It is a repair-layer design failure.
+A system that has no practical rollback owner is not responsibility-complete.
+
+### Repair path
+- define who can pause automated handling
+- define who can reverse incorrect escalations
+- define who records the repair event
+- define which signals require manual authority rebinding
+
+### Design lesson
+Repairability must be owned, not merely available.
+
+---
+
+## Example 3: Executive intent and operational execution diverge
+
+### Situation
+Leadership states that AI should be used only as decision support.
+At the operational layer, teams begin treating AI output as a default answer because throughput pressure rewards compliance speed.
+
+### Pathway break
+- intent layer and execution layer diverged
+- interface and workflow normalized passive acceptance
+- authority drift occurred without explicit policy update
+
+### Failure reading
+The pathway is broken between declared intent and actual operating behavior.
+This is not solved by naming a single guilty individual.
+
+### Repair path
+- inspect where workflow incentives pushed passive adoption
+- restore explicit policy-to-operation binding
+- add review checkpoints where output becomes action
+- measure whether staff still exercise judgment in practice
+
+### Design lesson
+A declared policy is not a sound pathway if the operating layer silently rewrites it.
+
+---
+
+## Example 4: Responsibility appears assigned after the fact, but cannot be reconstructed
+
+### Situation
+After an incident, the organization points to a nominal owner.
+However, logs do not clearly show who approved, who overrode, or whether the decision path passed through a required checkpoint.
+
+### Pathway break
+- record layer is too weak to reconstruct authority flow
+- nominal assignment exists, but inspectability does not
+
+### Failure reading
+Responsibility that cannot be reconstructed is structurally incomplete.
+Naming an owner afterward does not repair a missing pathway trace.
+
+### Repair path
+- improve logging of approvals and overrides
+- preserve decision checkpoints in system records
+- define minimum reconstruction requirements for high-impact decisions
+
+### Design lesson
+Record design is part of responsibility design.
+
+---
+
+## Example 5: Human override exists in theory but is unusable in practice
+
+### Situation
+The deployment documentation says that humans can always override the AI.
+In practice, the interface makes override difficult, costly, or socially discouraged.
+
+### Pathway break
+- interface layer conceals practical authority
+- execution layer favors system continuation over human interruption
+- human authority exists nominally but not operationally
+
+### Failure reading
+This is not a simple UX problem.
+It is a responsibility accessibility failure.
+The pathway claims reversibility but does not support real exercise of authority.
+
+### Repair path
+- redesign interface to make override visible and cheap enough to use
+- define protected conditions for interruption
+- ensure override use does not require heroic effort
+
+### Design lesson
+A pathway is unsound if authority exists only on paper.
+
+---
+
+## General Interpretation Pattern
+When analyzing a case with RPD, ask in order:
+1. What was the intended objective?
+2. Where was decision authority supposed to be?
+3. Where did delegation occur?
+4. Who or what executed?
+5. Did the interface clarify or hide authority?
+6. Can the record reconstruct the pathway?
+7. Who could stop, override, repair, or roll back?
+8. After failure, where should responsibility be rebound?
+
+## Practical Use
+These examples can be used as:
+- workshop material
+- policy discussion prompts
+- governance review aids
+- deployment pre-mortem prompts
+- incident post-mortem structure seeds
+
+## Relationship to Other Docs
+This document should be read together with:
+- `docs/principles.md`
+- `docs/layer-model.md`
+
+The principles define the logic.
+The layer model defines the analytical space.
+These examples show how the framework begins to operate on real patterns.

--- a/docs/layer-model.md
+++ b/docs/layer-model.md
@@ -1,0 +1,143 @@
+# Responsibility Pathway Design — Layer Model
+
+## Purpose
+This document introduces a layered model for analyzing where responsibility is carried, broken, obscured, or repaired.
+
+RPD is not limited to a single handoff between actor A and actor B.
+In AI-involved environments, responsibility often travels across multiple layers simultaneously.
+A pathway may appear intact at one layer while already broken at another.
+
+## Why a Layer Model is Needed
+Modern systems combine:
+- policy
+- organization
+- software
+- workflow
+- model outputs
+- interfaces
+- records
+
+A failure may be visible only at the surface while its cause lives in another layer.
+RPD therefore treats responsibility as a multi-layer pathway.
+
+## Proposed Layer Model
+
+### Layer 1: Intent Layer
+What was the system or organization trying to achieve?
+
+Key questions:
+- What was the intended objective?
+- Who defined it?
+- Was the objective explicit or only assumed?
+
+Typical break:
+- execution follows a pattern that no longer matches the real objective
+
+### Layer 2: Decision Layer
+Where was authority to decide actually located?
+
+Key questions:
+- Who had decision authority?
+- Was authority delegated?
+- Was delegation explicit?
+- Was accountability rebound after delegation?
+
+Typical break:
+- decision moved, responsibility did not
+
+### Layer 3: Execution Layer
+Who or what performed the action?
+
+Key questions:
+- Which human role, team, or AI system executed?
+- Was execution supervised?
+- Could execution be interrupted?
+
+Typical break:
+- execution continued under weak or unclear ownership
+
+### Layer 4: Interface Layer
+How was action surfaced to the human operator?
+
+Key questions:
+- Was the human aware of what the system was doing?
+- Did the interface make authority clear or hide it?
+- Were override paths visible?
+
+Typical break:
+- fluent interface behavior masks authority drift or automation creep
+
+### Layer 5: Model / System Behavior Layer
+How did the underlying AI or software behave?
+
+Key questions:
+- What role did model output play?
+- Was the behavior bounded?
+- Were limitations understood?
+- Did the system amplify ambiguity?
+
+Typical break:
+- model behavior becomes functionally authoritative without explicit ownership
+
+### Layer 6: Record Layer
+What trace was left behind?
+
+Key questions:
+- What was logged?
+- Can the pathway be reconstructed?
+- Are approvals, overrides, and rollback actions visible?
+
+Typical break:
+- failure cannot be reconstructed because record design was too weak
+
+### Layer 7: Repair Layer
+How can the pathway be stopped, repaired, rebound, or rolled back?
+
+Key questions:
+- Who can stop the flow?
+- Who can rebind responsibility?
+- What is the rollback path?
+- Who records the repair?
+
+Typical break:
+- nominal accountability exists, but no repair path exists in practice
+
+## Interpretation Rule
+A responsibility pathway should not be evaluated only by its visible surface behavior.
+It should be checked layer by layer.
+
+A system is not well-designed merely because:
+- it appears efficient
+- the AI output looks reasonable
+- one owner can be named afterward
+
+A pathway is sound only when responsibility remains legible and repairable across layers.
+
+## Example Diagnosis Pattern
+A common modern failure might look like this:
+- Intent layer: deliver faster decisions
+- Decision layer: authority partially delegated to AI-assisted workflow
+- Execution layer: staff rely on recommendation without active rebinding
+- Interface layer: system presents recommendation as seamless next step
+- Model layer: AI output becomes de facto authority
+- Record layer: no clear trace of human confirmation
+- Repair layer: no one clearly owns rollback
+
+In such a case, the failure is not only "human error" or "AI error."
+It is a pathway design failure across layers.
+
+## Practical Use
+This layer model can be used to:
+- diagnose incidents
+- design governance flows
+- review AI deployment plans
+- evaluate role boundaries
+- define override and rollback structures
+- improve organizational accountability design
+
+## Relationship to Principles
+This document should be read together with:
+- `docs/principles.md`
+
+The principles define the core logic of RPD.
+The layer model defines where that logic should be inspected and applied.

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,0 +1,114 @@
+# Responsibility Pathway Design — Principles
+
+## Purpose
+This document extracts the core design principles of Responsibility Pathway Design (RPD) as a reusable framework layer.
+
+RPD is not only a concept for describing accountability after failure.
+It is a design framework for structuring how responsibility should be carried, delegated, bounded, repaired, and re-bound in environments where AI participates in judgment and execution.
+
+## Core Position
+Responsibility must be designed before failure, not narrated only after failure.
+
+RPD begins from a failure-first view, but it does not remain there.
+Its purpose is to make responsibility pathways visible enough that:
+- breaks can be detected
+- ownership gaps can be identified
+- repair can be executed
+- future pathways can be redesigned more safely
+
+## Principle 1: Responsibility is a pathway, not a point
+Responsibility should not be reduced to a single owner label.
+It exists as a pathway that connects:
+- decision
+- delegation
+- execution
+- outcome
+- repair
+- accountability
+
+A system can appear to have an owner while still having a broken pathway.
+RPD therefore treats responsibility as a flow structure.
+
+## Principle 2: Delegation without rebinding is a structural defect
+When judgment or execution is delegated to another role, team, system, or AI component, accountability must be explicitly rebound.
+
+If execution moves but responsibility does not, the pathway becomes discontinuous.
+That discontinuity is one of the main sources of modern accountability failure.
+
+## Principle 3: AI participation increases the need for pathway design
+AI systems compress, accelerate, and partially obscure judgment and execution.
+This does not remove human responsibility.
+It increases the need to design:
+- ownership boundaries
+- override conditions
+- review points
+- rollback rights
+- failure interpretation paths
+
+## Principle 4: Failure should be interpreted structurally
+When things go wrong, the key question is not only "who failed?"
+The deeper question is:
+"where did the pathway break?"
+
+RPD therefore treats failure analysis as pathway diagnosis.
+
+## Principle 5: Repair is part of responsibility
+Responsibility design is incomplete if it defines only normal flow.
+It must also define:
+- who can stop the process
+- who can override automated output
+- who can rebind authority
+- who records the repair
+- how reversibility is preserved
+
+## Principle 6: Responsibility must remain legible across layers
+A pathway can break not only between people, but across layers such as:
+- policy
+- management
+- operations
+- interface
+- model behavior
+- record keeping
+
+RPD therefore requires multi-layer legibility.
+A pathway is not sound if one layer appears governed while another is opaque.
+
+## Principle 7: Records are part of the pathway
+If responsibility cannot be reconstructed afterward, then the pathway was underdesigned.
+
+Logs, decisions, approvals, overrides, and rollback traces are not peripheral artifacts.
+They are part of responsibility itself.
+
+## Principle 8: Repairability is as important as assignability
+A system may succeed at assigning nominal responsibility while failing to support actual repair.
+RPD prefers systems where responsibility is:
+- assignable
+- inspectable
+- interruptible
+- repairable
+- re-bindable
+
+## Principle 9: Human authority should not disappear behind system fluency
+Highly fluent systems can make delegation feel natural and harmless.
+But fluent execution can hide authority drift.
+RPD treats smooth operation as potentially dangerous when rebinding and override are unclear.
+
+## Principle 10: Responsibility design should remain adaptable
+Responsibility pathways change as organizations, tools, and AI roles change.
+RPD is therefore not a fixed checklist.
+It is a framework for ongoing redesign.
+
+## Practical Meaning
+RPD can be used to ask questions such as:
+- Where is decision authority actually located?
+- Where does delegation occur?
+- Where does ownership become ambiguous?
+- Who can stop or override the system?
+- What is the repair path after failure?
+- What must be logged so the pathway can be reconstructed?
+
+## Next Layer
+This principles document should be read together with:
+- `docs/layer-model.md`
+- future failure / repair examples
+- future governance and operating examples


### PR DESCRIPTION
## Summary
This PR moves `responsibility-pathway-design` from pure concept-definition toward a more explicit framework structure.

It adds two initial docs under `docs/`:
- `principles.md`
- `layer-model.md`

## Why
The current repository already explains what Responsibility Pathway Design is, but it does not yet expose enough reusable structure for practical application.

This PR introduces:
- a principles layer
- a multi-layer diagnosis model

Together, they begin shifting the repository from concept introduction toward framework articulation.

## Added
- Core principles of RPD
- Layered responsibility-path diagnosis model
- A clearer basis for future docs such as failure/repair examples, governance cases, and terminology

## Position
This is intentionally a draft-step PR.
It is meant to establish structure safely before any larger README refactor.
