### PR TITLE
Position RPD above harness engineering and add terminology docs

### DIFF
--- a/docs/operating-questions.md
+++ b/docs/operating-questions.md
@@ -1,0 +1,73 @@
+# Responsibility Pathway Design — Operating Questions
+
+## Purpose
+This document turns RPD into a compact working checklist for design review, deployment review, incident review, and organizational discussion.
+
+It is not a governance checklist in the usual sense.
+It is a pathway review tool.
+The point is not only to ask who is responsible, but whether responsibility can still move, return, stop, and repair under real operation.
+
+## Core Review Questions
+
+### 1. Intent
+- What is this system actually trying to optimize?
+- Who defined that objective?
+- Is the intended objective still the real operating objective?
+
+### 2. Decision
+- Where is decision authority actually located?
+- Is authority delegated anywhere?
+- After delegation, where is accountability rebound?
+
+### 3. Execution
+- Who or what executes the action?
+- Can execution continue without visible human ownership?
+- What happens if the system behaves fluently but incorrectly?
+
+### 4. Human Return
+- At which point can a human role take authority back?
+- Is that return point explicit, visible, and practical?
+- Does the human role have real override power or only nominal approval power?
+
+### 5. Interruption
+- Who can stop the flow?
+- Under what conditions must the flow be paused?
+- Is interruption cheap enough to be used in practice?
+
+### 6. Record
+- Can the pathway be reconstructed afterward?
+- Are approvals, overrides, and handoffs visible?
+- Is there enough trace to show where responsibility moved?
+
+### 7. Repair
+- Who owns repair after failure?
+- Who can rebind authority?
+- Who owns rollback?
+- Who records the repair and the new binding state?
+
+### 8. Organizational Transition
+- At what point does responsibility stop being a local operator issue and become an organizational responsibility?
+- Is that transition explicit?
+- Is there a named owner for that transition?
+
+## Interpretation Rule
+If a design cannot answer these questions clearly, the pathway is underdesigned.
+If a deployment cannot answer them under pressure, the pathway is fragile.
+If an incident review cannot answer them afterward, the pathway was not sufficiently legible.
+
+## Practical Use Cases
+This document can be used in:
+- AI deployment review meetings
+- governance workshops
+- incident post-mortems
+- pre-mortems for new AI workflows
+- role-boundary redesign sessions
+- executive review of AI operating risk
+
+## Relationship to Other Documents
+This document should be read together with:
+- `docs/principles.md`
+- `docs/layer-model.md`
+- `docs/failure-and-repair-examples.md`
+- `docs/positioning-above-harness-engineering.md`
+- `docs/terminology-and-nearby-concepts.md`

--- a/docs/positioning-above-harness-engineering.md
+++ b/docs/positioning-above-harness-engineering.md
@@ -1,0 +1,84 @@
+# Responsibility Pathway Design — Positioning Above Harness Engineering
+
+## Purpose
+This document clarifies where Responsibility Pathway Design (RPD) sits relative to recent discussions such as prompt engineering, context engineering, harness engineering, governance, and accountability design.
+
+RPD should not be read as another local optimization technique for AI output.
+It is a higher-order design layer for governing how responsibility flows across systems that already use such techniques.
+
+## Short Thesis
+Harness engineering asks:
+- how should AI execution be structured?
+- how should context, tools, checks, and runtime behavior be stabilized?
+
+Responsibility Pathway Design asks:
+- whose responsibility is the flow carrying?
+- where can the flow be stopped?
+- where does responsibility return to a human role?
+- where does organizational responsibility begin?
+- who owns repair and rollback after failure?
+
+## Why This Layer Is Needed
+A system can be excellent at:
+- execution stability
+- context management
+- tool orchestration
+- verification loops
+- durable state
+and still fail at responsibility.
+
+That happens when:
+- authority drifts without explicit rebinding
+- human return points are unclear
+- rollback exists technically but not organizationally
+- records exist but cannot reconstruct responsibility flow
+- governance exists outside the live pathway rather than inside it
+
+RPD exists to make those pathways legible before failure, during interruption, and after repair.
+
+## Placement Relative to Other Concepts
+
+### Prompt Engineering
+Prompt engineering shapes immediate output behavior.
+RPD does not compete with it.
+RPD asks what responsibility structure surrounds systems that rely on prompts.
+
+### Context Engineering
+Context engineering stabilizes memory, retrieval, and working context.
+RPD asks how responsibility is carried across those stabilized contexts.
+A better context window does not by itself create a safe responsibility pathway.
+
+### Harness Engineering
+Harness engineering structures execution through tools, runtime controls, verification, and external state.
+RPD stands above that layer.
+Harness engineering stabilizes execution.
+RPD governs how judgment, delegation, interruption, repair, and ownership flow across that execution.
+
+### Governance
+Governance defines rules, roles, committees, and oversight structures.
+RPD is not a replacement for governance.
+It is the design layer that asks whether responsibility can still be traced, interrupted, rebound, and repaired when governance meets real operating flow.
+
+### Accountability Design
+Accountability design often asks who is responsible.
+RPD asks how responsibility moves, where it breaks, and how it returns.
+That makes it especially relevant in AI-involved environments where execution can be partially delegated, accelerated, or obscured.
+
+## Practical Reading Rule
+If a concept explains:
+- how to structure AI execution,
+then it is below RPD.
+
+If a concept explains:
+- how to preserve responsibility continuity, rebinding, interruption, repair, and rollback ownership across that execution,
+then it is part of RPD territory.
+
+## One-Sentence Definition
+Responsibility Pathway Design is a higher-order design layer for governing how judgment, delegation, execution, interruption, repair, and organizational responsibility flow across AI-involved systems.
+
+## Relationship to Other Documents
+This document should be read together with:
+- `docs/principles.md`
+- `docs/layer-model.md`
+- `docs/failure-and-repair-examples.md`
+- `docs/terminology-and-nearby-concepts.md`

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,0 +1,85 @@
+# Start Here — Responsibility Pathway Design (RPD)
+
+If you are new to this repository, start with this page.
+
+Responsibility Pathway Design (RPD) is a framework for designing how responsibility:
+- flows
+- breaks
+- returns
+- is rebound
+- is repaired
+across AI-involved systems.
+
+RPD is not another local execution technique.
+It sits above prompt engineering, context engineering, harness engineering, and governance checklists as a higher-order design layer for responsibility continuity.
+
+## Read This First
+
+### 1. Core principles
+Read:
+- `docs/principles.md`
+
+This explains the basic logic of RPD:
+- responsibility is a pathway, not a point
+- delegation without rebinding is a defect
+- repair and rollback are part of responsibility
+- records are part of the pathway
+
+### 2. Layer model
+Read:
+- `docs/layer-model.md`
+
+This explains where pathway breaks can occur across:
+- intent
+- decision
+- execution
+- interface
+- model behavior
+- records
+- repair
+
+### 3. Failure and repair examples
+Read:
+- `docs/failure-and-repair-examples.md`
+
+This shows how pathway failures appear in practice and how repair, rollback, and rebinding can be designed.
+
+### 4. Positioning above harness engineering
+Read:
+- `docs/positioning-above-harness-engineering.md`
+
+This explains why RPD should be read as a layer above current AI execution discourse.
+
+### 5. Terminology and nearby concepts
+Read:
+- `docs/terminology-and-nearby-concepts.md`
+
+This clarifies how RPD differs from nearby labels such as:
+- Responsibility Engineering
+- Responsibility Architecture
+- End-to-End Accountability Design
+- Sociotechnical Governance
+- AI Governance
+- Human-in-the-loop
+
+### 6. Operating questions
+Read:
+- `docs/operating-questions.md`
+
+This turns the framework into a compact review lens for live systems.
+
+## Recommended Reading Path
+- New to RPD:
+  1. `docs/principles.md`
+  2. `docs/layer-model.md`
+  3. `docs/positioning-above-harness-engineering.md`
+- Designing or reviewing deployment:
+  1. `docs/operating-questions.md`
+  2. `docs/failure-and-repair-examples.md`
+  3. `docs/layer-model.md`
+- Comparing RPD with nearby concepts:
+  1. `docs/terminology-and-nearby-concepts.md`
+  2. `docs/positioning-above-harness-engineering.md`
+
+## One-Sentence Summary
+Responsibility Pathway Design is a higher-order design framework for governing how judgment, delegation, execution, interruption, repair, and organizational responsibility flow across AI-involved systems.

--- a/docs/terminology-and-nearby-concepts.md
+++ b/docs/terminology-and-nearby-concepts.md
@@ -1,0 +1,126 @@
+# Responsibility Pathway Design — Terminology and Nearby Concepts
+
+## Purpose
+This document clarifies how Responsibility Pathway Design (RPD) relates to nearby concepts that may sound similar but do not center the same design problem.
+
+The goal is not to reject these concepts.
+It is to prevent conceptual flattening.
+RPD becomes less useful when it is reduced to a generic label for accountability, governance, or architecture.
+
+## Core Distinction
+RPD centers:
+- responsibility flow
+- breakpoints
+- rebinding points
+- stop points
+- human return points
+- repair paths
+- rollback ownership
+- transition into organizational responsibility
+
+Many nearby concepts overlap partially.
+Few center all of these at once.
+
+## Nearby Concepts
+
+### Responsibility Engineering
+Close in motivation, but not identical.
+
+Responsibility Engineering tends to emphasize:
+- structuring responsibility
+- assigning or clarifying responsibility
+- engineering traceability and protocol
+
+RPD goes further by treating responsibility as a pathway that:
+- moves
+- breaks
+- returns
+- is rebound
+- must remain repairable
+
+Practical distinction:
+Responsibility Engineering asks how responsibility should be structured.
+RPD asks how responsibility should flow.
+
+### Responsibility Architecture
+This can be a useful neighboring term when the focus is on static structure.
+RPD is compatible with it, but places more emphasis on continuity under live operation.
+
+Practical distinction:
+Responsibility Architecture asks what the structure looks like.
+RPD asks what happens when the structure is under pressure, delegation, interruption, and repair.
+
+### End-to-End Accountability Design
+This is one of the closest neighboring concepts.
+It captures continuity better than many governance terms.
+However, RPD is still more explicit about:
+- rebinding after delegation
+- stop points
+- human return points
+- repair ownership
+- rollback authority
+
+Practical distinction:
+End-to-End Accountability Design stresses continuity.
+RPD stresses continuity plus diagnosable breakpoints and repair authority.
+
+### Sociotechnical Governance
+This is broad and often useful.
+It captures the fact that responsibility failures occur across humans, institutions, interfaces, and systems.
+RPD fits inside that concern, but is more operationally specific.
+
+Practical distinction:
+Sociotechnical Governance asks how mixed human-technical systems should be governed.
+RPD asks where responsibility breaks inside those systems and how it should be repaired.
+
+### AI Governance
+AI governance provides policies, roles, committees, controls, and review structures.
+RPD depends on governance, but does not collapse into it.
+
+Practical distinction:
+Governance sets rules.
+RPD asks whether responsibility still remains legible, interruptible, and repairable when those rules meet live operation.
+
+### Human-in-the-loop
+Human-in-the-loop is often treated as a safety answer by itself.
+RPD treats it as insufficient unless the human role clearly owns:
+- review authority
+- interruption authority
+- override authority
+- rebound responsibility after delegation
+
+Practical distinction:
+Human-in-the-loop asks whether a human is present.
+RPD asks whether that human actually carries meaningful return authority.
+
+### Logging and Auditability
+Logs and audits matter, but they are not the pathway itself.
+RPD treats records as part of the pathway only when they allow reconstruction of how responsibility moved and where it broke.
+
+Practical distinction:
+Auditability asks whether something was recorded.
+RPD asks whether the responsibility pathway can be reconstructed and acted upon.
+
+## Summary Table
+
+| Concept | Primary focus | What RPD adds |
+|---|---|---|
+| Responsibility Engineering | structure and traceability | flow, break, return, rebinding, repair |
+| Responsibility Architecture | static accountability structure | live continuity under delegation and interruption |
+| End-to-End Accountability Design | continuity of accountability | explicit breakpoints, return points, rollback ownership |
+| Sociotechnical Governance | broad human-technical governance | operational pathway diagnosis and repair |
+| AI Governance | rules, oversight, committees | responsibility continuity during live execution |
+| Human-in-the-loop | human presence in loop | meaningful authority return and override ownership |
+| Logging / Auditability | recordability | reconstructable responsibility pathway |
+
+## Interpretation Rule
+If a term can explain responsibility only after the fact, it is not enough for RPD.
+If a term cannot explain where responsibility should return during live failure, it is not enough for RPD.
+If a term cannot define who owns repair and rollback, it is not enough for RPD.
+
+## Relationship to Other Documents
+This document should be read together with:
+- `docs/principles.md`
+- `docs/layer-model.md`
+- `docs/failure-and-repair-examples.md`
+- `docs/positioning-above-harness-engineering.md`


### PR DESCRIPTION
## Summary
This PR advances the repository from a compact framework skeleton toward a clearer v0.2 positioning layer.

It adds three new documents:
- `docs/positioning-above-harness-engineering.md`
- `docs/terminology-and-nearby-concepts.md`
- `docs/operating-questions.md`

## Why
Recent work clarified that Responsibility Pathway Design (RPD) should not be framed as another local harness technique.
It is better positioned as a higher-order design layer governing how responsibility flows across systems that already use prompt engineering, context engineering, harness engineering, governance, and related accountability structures.

This PR therefore strengthens three areas:
1. **Positioning** — where RPD sits relative to harness engineering and governance
2. **Terminology** — how RPD differs from nearby concepts such as Responsibility Engineering, Responsibility Architecture, End-to-End Accountability Design, Sociotechnical Governance, and Human-in-the-loop
3. **Operation** — how to ask practical review questions when applying RPD in live systems

## Notes
- This PR intentionally does not rewrite the top-level `README.md` yet.
- README rewiring can be done in the next PR once the new document set is reviewed as a bundle.
- The goal here is to land the conceptual core first, then simplify repo entrypoints.

## Expected effect
After this PR, the repository should read less like a concept placeholder and more like an emerging framework with:
- core principles
- a layer model
- failure and repair examples
- positioning against current AI execution discourse
- terminology differentiation
- a compact operating review lens
