### PR TITLE
Add top-level entrypoint for RPD v0.2 repository structure

### DIFF
--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,0 +1,40 @@
+# Start Here — Responsibility Pathway Design (RPD)
+
+This repository has moved beyond a simple concept placeholder.
+It now contains the beginnings of a reusable framework for designing how responsibility flows across AI-involved systems.
+
+If you are opening this repository for the first time, begin here.
+
+## What RPD is
+Responsibility Pathway Design (RPD) is a higher-order design framework for governing how:
+- judgment
+- delegation
+- execution
+- interruption
+- repair
+- rollback
+- organizational responsibility
+flow across AI-involved systems.
+
+RPD is not another harness technique.
+It sits above prompt engineering, context engineering, harness engineering, governance structures, and accountability assignment.
+
+## Recommended reading order
+1. `docs/start-here.md`
+2. `docs/principles.md`
+3. `docs/layer-model.md`
+4. `docs/failure-and-repair-examples.md`
+5. `docs/positioning-above-harness-engineering.md`
+6. `docs/terminology-and-nearby-concepts.md`
+7. `docs/operating-questions.md`
+
+## Quick orientation
+- If you want the core logic, read `docs/principles.md`
+- If you want to see where pathway failure happens, read `docs/layer-model.md`
+- If you want realistic patterns, read `docs/failure-and-repair-examples.md`
+- If you want to understand how RPD sits above harness engineering, read `docs/positioning-above-harness-engineering.md`
+- If you want nearby-concept comparison, read `docs/terminology-and-nearby-concepts.md`
+- If you want to use the framework in review or deployment, read `docs/operating-questions.md`
+
+## One-sentence summary
+Responsibility Pathway Design asks not only who is responsible, but how responsibility moves, where it breaks, where it returns, and who owns repair when AI participates in judgment and execution.


### PR DESCRIPTION
## Summary
This PR adds a top-level `START-HERE.md` file as a cleaner repository entrypoint after the recent v0.2 positioning merge.

## Why
The repository now contains a much stronger framework core than the current top-level entry experience suggests.
A new reader can still land on the repository and miss the newer structure.

This PR provides a safe, minimal entrypoint improvement without directly rewriting the existing `README.md` in the same step.

## What it adds
- `START-HERE.md` at repository root

This file:
- explains what RPD is in one page
- points readers to the current document set in a recommended order
- makes the v0.2 structure legible even before README rewiring

## Why this approach
Direct README rewiring can still be done next.
This PR is intentionally smaller and safer:
- it improves first-contact readability now
- it keeps repository history clean
- it allows README redesign to be handled as its own focused step

## Expected effect
After this PR, a new visitor can more easily understand that the repository now includes:
- framework principles
- a layer model
- failure / repair examples
- positioning above harness engineering
- terminology differentiation
- operating review questions
