### PR TITLE
Add minimal Lean 4 formal scaffold and CI check

### DIFF
--- a/.github/workflows/lean_check.yml
+++ b/.github/workflows/lean_check.yml
@@ -1,0 +1,30 @@
+name: Lean Check
+
+on:
+  push:
+    paths:
+      - 'formal/**'
+      - '.github/workflows/lean_check.yml'
+  pull_request:
+    paths:
+      - 'formal/**'
+      - '.github/workflows/lean_check.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: formal
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Build with Lake
+        run: lake build

--- a/formal/Formal/Basic.lean
+++ b/formal/Formal/Basic.lean
@@ -1,0 +1,10 @@
+namespace Formal
+
+-- Explicit boundaries:
+-- no_proof_claim
+-- not_theorem_grade
+-- not_final_proof_claim
+
+theorem smoke_test : (1 : Nat) = 1 := rfl
+
+end Formal

--- a/formal/lakefile.lean
+++ b/formal/lakefile.lean
@@ -1,0 +1,4 @@
+import Lake
+open Lake DSL
+
+package "formal" where


### PR DESCRIPTION
### Motivation

- Provide a minimal formal verification layer under `formal/` so the repository can host Lean 4 proofs and be smoke-tested by CI. 
- Include a tiny, obviously true theorem as a smoke test to validate toolchain and build steps without making any substantive proof claims. 

### Description

- Add a minimal Lake package file at `formal/lakefile.lean` declaring the `formal` package. 
- Add `formal/Formal/Basic.lean` containing only a smoke-test theorem `theorem smoke_test : (1 : Nat) = 1 := rfl` and explicit boundary markers: `no_proof_claim`, `not_theorem_grade`, and `not_final_proof_claim`. 
- Add GitHub Actions workflow `.github/workflows/lean_check.yml` that installs `elan` and runs `lake build` with working directory set to `formal`. 
- The change does not modify any existing `formal/lean-toolchain`; the workflow will respect an existing `formal/lean-toolchain` if present. 

### Testing

- Ran `cd formal && lake build` in the environment, which failed because the `lake` executable was not available (`/bin/bash: lake: command not found`). 
- A GitHub Actions job is provided to run `lake build` on push and pull requests touching `formal/**`, so CI will perform the build verification on GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043480dccc832a9fd4f87634f15dc0)